### PR TITLE
fix: full width layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,7 +1,7 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+  width: 100%;
+  margin: 0;
+  padding: 0;
   text-align: center;
 }
 


### PR DESCRIPTION
Fixed the homepage width issue on larger screens by removing the max-width constraint from #root in App.css. The app now uses full screen width on all screen sizes.