### PR TITLE
Fix code editor not showing code on initial load

### DIFF
--- a/frontend/src/page/ProblemPage.jsx
+++ b/frontend/src/page/ProblemPage.jsx
@@ -51,11 +51,23 @@ const ProblemPage = () => {
     getSubmissionCountForProblem(id);
   }, [id]);
 
+  // Handle initial problem load and set default language
   useEffect(() => {
-    if (problem) {
-      setCode(
-        problem.codeSnippets?.[selectedLanguage] || submission?.sourceCode || ""
-      );
+    if (problem && problem.codeSnippets) {
+      // Get available languages
+      const availableLanguages = Object.keys(problem.codeSnippets);
+      
+      // If current selected language doesn't have a code snippet, use the first available language
+      if (!problem.codeSnippets[selectedLanguage] && availableLanguages.length > 0) {
+        const firstAvailableLanguage = availableLanguages[0];
+        setSelectedLanguage(firstAvailableLanguage);
+        setCode(problem.codeSnippets[firstAvailableLanguage] || "");
+      } else {
+        // Set code for the selected language
+        setCode(problem.codeSnippets[selectedLanguage] || submission?.sourceCode || "");
+      }
+      
+      // Set test cases
       setTestCases(
         problem.testcases?.map((tc) => ({
           input: tc.input,
@@ -63,7 +75,14 @@ const ProblemPage = () => {
         })) || []
       );
     }
-  }, [problem, selectedLanguage]);
+  }, [problem]);
+
+  // Handle language change
+  useEffect(() => {
+    if (problem && problem.codeSnippets && problem.codeSnippets[selectedLanguage]) {
+      setCode(problem.codeSnippets[selectedLanguage]);
+    }
+  }, [selectedLanguage]);
 
   useEffect(() => {
     if (activeTab === "submissions" && id) {
@@ -74,7 +93,6 @@ const ProblemPage = () => {
   const handleLanguageChange = (e) => {
     const lang = e.target.value;
     setSelectedLanguage(lang);
-    setCode(problem.codeSnippets?.[lang] || "");
   };
 
   const handleRunCode = async (e) => {


### PR DESCRIPTION
## Bug Fix: Code Editor Not Showing Code on Initial Load

### Problem
The code editor was not displaying code snippets when initially opening a problem page. The code would only appear after manually changing the language in the dropdown.

### Root Cause
The issue was in the useEffect hooks that handle code snippet loading:
1. The default language was set to "javascript" but the problem might not have a JavaScript code snippet
2. The useEffect wasn't properly handling the initial load state

### Solution
1. Added a dedicated useEffect that runs when the problem data is loaded
2. Automatically selects the first available language if the default language doesn't have a code snippet
3. Separated the language change logic into its own useEffect for cleaner code

### Changes Made
- Modified the useEffect hook that handles initial problem loading to check for available languages
- If the selected language doesn't have a code snippet, it now automatically switches to the first available language
- Improved the code loading logic to ensure the editor always displays code on initial load

This fix ensures users see the code snippet immediately when opening a problem, improving the user experience.