### PR TITLE
Fix submissions not auto-updating after submit

### DIFF
--- a/frontend/src/page/ProblemPage.jsx
+++ b/frontend/src/page/ProblemPage.jsx
@@ -90,6 +90,16 @@ const ProblemPage = () => {
     }
   }, [activeTab, id]);
 
+  // Refresh submissions when a new submission is made
+  useEffect(() => {
+    if (submission && id) {
+      // Refresh submissions list
+      getSubmissionForProblem(id);
+      // Update submission count
+      getSubmissionCountForProblem(id);
+    }
+  }, [submission]);
+
   const handleLanguageChange = (e) => {
     const lang = e.target.value;
     setSelectedLanguage(lang);
@@ -111,7 +121,7 @@ const ProblemPage = () => {
     }
   };
 
-  const handleSubmitSolution = (e) => {
+  const handleSubmitSolution = async (e) => {
     e.preventDefault();
     setRunResults(null);
     
@@ -119,7 +129,7 @@ const ProblemPage = () => {
       const language_id = getLanguageId(selectedLanguage);
       const stdin = problem.testcases.map((tc) => tc.input);
       const expected_outputs = problem.testcases.map((tc) => tc.output);
-      executeCode(code, language_id, stdin, expected_outputs, id);
+      await executeCode(code, language_id, stdin, expected_outputs, id);
     } catch (error) {
       console.log("Error submitting solution", error);
     }


### PR DESCRIPTION
## Bug Fix: Submissions Not Auto-Updating After Submit

### Problem
When a user submits a solution, the submissions list in the "Submissions" tab doesn't update automatically. Users have to reload the page to see their new submission, even though submissions are correctly stored and visible on the profile page.

### Root Cause
The submissions list is only fetched when the user clicks on the "Submissions" tab. There was no mechanism to refresh the list after a successful submission.

### Solution
Added a `useEffect` hook that watches for new submissions and automatically:
1. Refreshes the submissions list
2. Updates the submission count

### Changes Made
- Added a new `useEffect` (lines 89-95) that triggers when the `submission` state changes
- Made `handleSubmitSolution` async to ensure proper execution flow
- When a new submission is detected, it automatically calls:
  - `getSubmissionForProblem(id)` - to refresh the submissions list
  - `getSubmissionCountForProblem(id)` - to update the submission count

This ensures users see their submissions immediately after submitting, without needing to refresh the page or switch tabs.